### PR TITLE
Use unauthenticated URL for bb-storage dependency.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,7 +36,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "com_github_buildbarn_bb_storage",
     commit = "91e95ab36b90259bea60e5b525182694e7450349",
-    remote = "git@github.com:buildbarn/bb-storage.git",
+    remote = "https://github.com/buildbarn/bb-storage.git",
 )
 
 load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories = "repositories")


### PR DESCRIPTION
`bb-browser` currently declares its dependency against `bb-storage` using a SSH GitHub URL. This patch changes the  `WORKSPACE` file to use the unauthenticated HTTP GitHub URL instead.