### PR TITLE
Handle Command messages with no Platform

### DIFF
--- a/cmd/bb_browser/templates/view_command.html
+++ b/cmd/bb_browser/templates/view_command.html
@@ -27,12 +27,14 @@
 		<th style="style: 25%">Working directory:</th>
 		<td class="text-monospace" style="width: 75%">{{if .WorkingDirectory}}{{.WorkingDirectory}}{{else}}.{{end}}</td>
 	</tr>
-	<tr>
-		<th style="width: 25%">Platform properties:</th>
-		<td style="width: 75%">
-			{{range .Platform.Properties}}
-				<b>{{.Name}}</b> = {{.Value}}<br/>
-			{{end}}
-		</td>
-	</tr>
+	{{if .Platform}}
+		<tr>
+			<th style="width: 25%">Platform properties:</th>
+			<td style="width: 75%">
+				{{range .Platform.Properties}}
+					<b>{{.Name}}</b> = {{.Value}}<br/>
+				{{end}}
+			</td>
+		</tr>
+	{{end}}
 </table>


### PR DESCRIPTION
If an input `Command` message does not have a `Platform` message attached, the HTML template processing will fail in error:

```
view_command.html:33:20: executing "view_command.html" at <.Platform.Properties>: can't evaluate field Properties in type *remoteexecution.Platform
```

This patch simply renders an empty _`Platform properties:`_ line if no `Platform` message is found.