### PR TITLE
Support reading ActionResult inline logs

### DIFF
--- a/cmd/bb_browser/browser_service.go
+++ b/cmd/bb_browser/browser_service.go
@@ -203,12 +203,28 @@ func (s *BrowserService) handleActionCommon(w http.ResponseWriter, req *http.Req
 
 		// TODO(edsch): Should we support Std{out,err}Raw as well? Buildbarn doesn't generate them.
 		var err error
-		actionInfo.StdoutInfo, err = s.getLogInfo(ctx, "Standard output", instance, actionResult.StdoutDigest)
+		if actionResult.StdoutDigest != nil {
+			actionInfo.StdoutInfo, err = s.getLogInfo(ctx, "Standard output", instance, actionResult.StdoutDigest)
+		} else if actionResult.StdoutRaw != nil {
+			actionInfo.StdoutInfo = &logInfo{
+				Name:     "Standard output",
+				Instance: instance,
+				HTML:     template.HTML(terminal.Render(actionResult.StdoutRaw)),
+			}
+		}
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		actionInfo.StderrInfo, err = s.getLogInfo(ctx, "Standard error", instance, actionResult.StderrDigest)
+		if actionResult.StderrDigest != nil {
+			actionInfo.StderrInfo, err = s.getLogInfo(ctx, "Standard error", instance, actionResult.StderrDigest)
+		} else if actionResult.StderrRaw != nil {
+			actionInfo.StderrInfo = &logInfo{
+				Name:     "Standard error",
+				Instance: instance,
+				HTML:     template.HTML(terminal.Render(actionResult.StderrRaw)),
+			}
+		}
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/cmd/bb_browser/templates/view_log.html
+++ b/cmd/bb_browser/templates/view_log.html
@@ -1,14 +1,21 @@
 {{if .}}
 	<tr>
-		<th style="width: 25%">{{.Name}}<sup><a href="/file/{{.Instance}}/{{.Digest.Hash}}/{{.Digest.SizeBytes}}/log.txt">*</a></sup>:</th>
-		<td class="width: 75%">
-			{{if .NotFound}}
-				The log file for this action could not be found.
-			{{else if .TooLarge}}
-				The log file for this action is too large to display ({{.Digest.SizeBytes}} bytes).
-			{{else}}
+		{{if .Digest}}
+			<th style="width: 25%">{{.Name}}<sup><a href="/file/{{.Instance}}/{{.Digest.Hash}}/{{.Digest.SizeBytes}}/log.txt">*</a></sup>:</th>
+			<td class="width: 75%">
+				{{if .NotFound}}
+					The log file for this action could not be found.
+				{{else if .TooLarge}}
+					The log file for this action is too large to display ({{.Digest.SizeBytes}} bytes).
+				{{else}}
+					<div class="term-container">{{.HTML}}</div>
+				{{end}}
+			</td>
+		{{else}}
+			<th style="width: 25%">{{.Name}}:</th>
+			<td class="width: 75%">
 				<div class="term-container">{{.HTML}}</div>
-			{{end}}
-		</td>
+			</td>
+		{{end}}
 	</tr>
 {{end}}


### PR DESCRIPTION
For stdout/stderr logs, an ActionResult can either store the textual content inline or simply hold a Digest to a blob in CAS. This patch adds support for the inline case, the Digest case being already implemented.