### PR TITLE
Support empty instance names

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,10 @@ Prebuilt container images of Buildbarn Browser may be found on
 [Docker Hub](https://hub.docker.com/r/buildbarn/bb-browser). More
 examples of how Buildbarn Browser may be deployed can be found in
 [the Buildbarn deployments repository](https://github.com/buildbarn/bb-deployments).
+
+### Usage with Empty Instance Names
+
+It is a valid for the remote execution instance name to be the empty
+string. This however causes ambiguity in the url syntax used for the various
+bb-browser pages. The special `_` character is used to represent the empty
+instance name since the empty string cannnot be passed.

--- a/cmd/bb_browser/browser_service.go
+++ b/cmd/bb_browser/browser_service.go
@@ -42,6 +42,11 @@ func getDigestFromRequest(req *http.Request) (*util.Digest, error) {
 	if err != nil {
 		return nil, err
 	}
+	if vars["instance"] == "_" {
+		// If special underbar instance name is used then treat that as the
+		// empty instance name otherwise url is ambiguous.
+		vars["instance"] = ""
+	}
 	return util.NewDigest(
 		vars["instance"],
 		&remoteexecution.Digest{


### PR DESCRIPTION
It is valid for a remote execution service and CAS to use an empty
instance name.

Unfortunately it seems somewhat ugly to add an optional path to gorilla
so had to double up all the router registrations. Happy to factor this
to be a bit prettier if desired.