### PR TITLE
Updated io_bazel_rules_go to 0.18.3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,8 +21,11 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "6776d68ebb897625dead17ae510eac3d5f6342367327875210df44dbe2aeeb19",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.17.1/rules_go-0.17.1.tar.gz"],
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
+    ],
+    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
 )
 
 http_archive(


### PR DESCRIPTION
Update to latest rules-go otherwise it breaks under latest bazel:

https://gitlab.com/remote-apis-testing/remote-apis-testing/-/jobs/232772409