### PR TITLE
Use the go_image_static base image for bb_browser_container

### DIFF
--- a/cmd/bb_browser/BUILD.bazel
+++ b/cmd/bb_browser/BUILD.bazel
@@ -58,6 +58,7 @@ container_layer(
 
 container_image(
     name = "bb_browser_container",
+    base = "@go_image_static//image",
     entrypoint = ["/bb_browser"],
     layers = [
         ":bb_browser_layer_executable",


### PR DESCRIPTION
While still using container_image this brings the produced container closer to that of the bb_storage container produced by go_image with `pure=true`. Not having this can lead to issues with TLS due to missing certificates.