### PR TITLE
Show data contained in BuildMetadata

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,8 +40,8 @@ http_archive(
 http_archive(
     name = "com_github_bazelbuild_bazel",
     patches = ["//:patches/com_github_bazelbuild_bazel/build_event_stream.diff"],
-    sha256 = "2cea463d611f5255d2f3d41c8de5dcc0961adccb39cf0ac036f07070ba720314",
-    urls = ["https://github.com/bazelbuild/bazel/releases/download/0.28.1/bazel-0.28.1-dist.zip"],
+    sha256 = "3371cd9050989173a3b27364668328653a65653a50a85c320adc53953b4d5f46",
+    urls = ["https://github.com/bazelbuild/bazel/releases/download/2.1.0/bazel-2.1.0-dist.zip"],
 )
 
 http_archive(

--- a/cmd/bb_browser/templates/page_build_events.html
+++ b/cmd/bb_browser/templates/page_build_events.html
@@ -63,6 +63,18 @@
 			</td>
 		</tr>
 	{{end}}
+	{{with .BuildMetadata}}
+		{{if .Payload.Metadata}}
+			<tr>
+				<th style="width: 25%">Metadata:</th>
+				<td class="text-monospace" style="width: 75%; overflow-x: scroll; white-space: nowrap">
+					{{range $key, $value := .Payload.Metadata}}
+						<b>{{$key}}</b>={{shellquote $value}}<br/>
+					{{end}}
+				</td>
+			</tr>
+		{{end}}
+	{{end}}
 	{{with .WorkspaceStatus}}
 		<tr>
 			<th style="width: 25%">Workspace status:</th>

--- a/pkg/buildevents/nodes.go
+++ b/pkg/buildevents/nodes.go
@@ -43,6 +43,10 @@ func (n *defaultNode) addBuildFinishedNode(child *BuildFinishedNode) error {
 	return status.Error(codes.InvalidArgument, "Value cannot be placed at this location")
 }
 
+func (n *defaultNode) addBuildMetadataNode(child *BuildMetadataNode) error {
+	return status.Error(codes.InvalidArgument, "Value cannot be placed at this location")
+}
+
 func (n *defaultNode) addBuildMetricsNode(child *BuildMetricsNode) error {
 	return status.Error(codes.InvalidArgument, "Value cannot be placed at this location")
 }
@@ -419,6 +423,7 @@ type StartedNode struct {
 	Payload *buildeventstream.BuildStarted
 
 	BuildFinished            *BuildFinishedNode
+	BuildMetadata            *BuildMetadataNode
 	OptionsParsed            *OptionsParsedNode
 	Patterns                 []*PatternNode
 	Progress                 *ProgressNode
@@ -434,6 +439,14 @@ func (n *StartedNode) addBuildFinishedNode(child *BuildFinishedNode) error {
 		return status.Error(codes.InvalidArgument, "Value already set")
 	}
 	n.BuildFinished = child
+	return nil
+}
+
+func (n *StartedNode) addBuildMetadataNode(child *BuildMetadataNode) error {
+	if n.BuildMetadata != nil {
+		return status.Error(codes.InvalidArgument, "Value already set")
+	}
+	n.BuildMetadata = child
 	return nil
 }
 
@@ -501,6 +514,16 @@ func (n *StartedNode) GetFilesForNamedSets(namedSets []*buildeventstream.BuildEv
 	}
 	sort.Sort(files)
 	return files
+}
+
+// BuildMetadataNode corresponds to a Build Event Protocol message with
+// BuildEventID kind `build_metadata` and BuildEvent payload kind
+// `build_metadata`.
+type BuildMetadataNode struct {
+	defaultNode
+
+	ID      *buildeventstream.BuildEventId_BuildMetadataId
+	Payload *buildeventstream.BuildMetadata
 }
 
 // StructuredCommandLineNode corresponds to a Build Event Protocol


### PR DESCRIPTION
This change adds support for the event BuildMetadata. The information
will be only presented if any data is provided in the event message.
The event type was introduced in bazel 1.0.0.

Fixes: #15