### PR TITLE
Enable more autoformatters on our codebase

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+Language: Proto
+BasedOnStyle: Google

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -7,24 +7,20 @@ on:
     branches:
     - master
 jobs:
-  gofmt:
-    runs-on: ubuntu-latest
-    container: docker://golang:1.13
-    steps:
-    - uses: actions/checkout@v1
-    - name: run gofmt
-      run: test -z "$(gofmt -d . | tee /dev/stderr)"
-  gazelle:
+  build_and_test:
     runs-on: ubuntu-latest
     container: docker://l.gcr.io/google/bazel:2.1.0
     steps:
     - uses: actions/checkout@v1
-    - name: run gazelle
-      run: bazel run :gazelle && git diff --exit-code HEAD --
-  build:
-    runs-on: ubuntu-latest
-    container: docker://l.gcr.io/google/bazel:2.1.0
-    steps:
-    - uses: actions/checkout@v1
-    - name: build
+    - name: Bazel build
       run: bazel build //...
+    - name: Buildifier
+      run: bazel run @com_github_bazelbuild_buildtools//:buildifier
+    - name: Gazelle
+      run: bazel run //:gazelle
+    - name: Gofmt
+      run: bazel run @go_sdk//:bin/gofmt -- -s -w .
+    - name: Clang format
+      run: find . -name '*.proto' -exec bazel run @llvm_toolchain//:bin/clang-format -- -i {} +
+    - name: Test style conformance
+      run: git diff --exit-code HEAD --

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -122,3 +122,17 @@ http_archive(
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
+
+http_archive(
+    name = "com_grail_bazel_toolchain",
+    sha256 = "b3dec631fe2be45b3a7a8a4161dd07fadc68825842e8d6305ed35bc8560968ca",
+    strip_prefix = "bazel-toolchain-0.5.1",
+    urls = ["https://github.com/grailbio/bazel-toolchain/archive/0.5.1.tar.gz"],
+)
+
+load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
+
+llvm_toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "9.0.0",
+)


### PR DESCRIPTION
Instead of having separate containers that do a 'go get' to obtain these
tools, fetch all of them through the Bazel workspace. This ensures that
we always stick to a fixed version.