### PR TITLE
Revert "make the download link for the log file more obvious"

### DIFF
--- a/cmd/bb_browser/templates/view_log.html
+++ b/cmd/bb_browser/templates/view_log.html
@@ -5,7 +5,7 @@
 			{{if .NotFound}}
 				The log file for this action could not be found.
 			{{else if .TooLarge}}
-				The <a href="/file/{{.GetInstance}}/{{.GetHashString}}/{{.GetSizeBytes}}/log.txt">log file</a> for this action is too large to display ({{.Digest.GetSizeBytes}} bytes).
+				The log file for this action is too large to display ({{.Digest.GetSizeBytes}} bytes).
 			{{else}}
 				<div class="term-container">{{.HTML}}</div>
 			{{end}}


### PR DESCRIPTION
Reverts buildbarn/bb-browser#23

The URL accesses template fields that don't exist.