### PR TITLE
Fix malformed templating for long logs

### DIFF
--- a/cmd/bb_browser/templates/view_log.html
+++ b/cmd/bb_browser/templates/view_log.html
@@ -5,7 +5,7 @@
 			{{if .NotFound}}
 				The log file for this action could not be found.
 			{{else if .TooLarge}}
-				The log file for this action is too large to display ({{.Digest.GetSizeBytes}} bytes).
+				The {{with .Digest}}<a href="/file/{{.GetInstance}}/{{.GetHashString}}/{{.GetSizeBytes}}/log.txt">log file</a> for this action is too large to display ({{.GetSizeBytes}} bytes{{end}}).
 			{{else}}
 				<div class="term-container">{{.HTML}}</div>
 			{{end}}


### PR DESCRIPTION
This addresses https://github.com/buildbarn/bb-browser/issues/24 and fixes the malformed pages generated by a failure to process values in the templates.

The scope started by `{{with .Digest}}` was closed at the end of line 3 and therefore the values were not valid in the scope on line 8.