### PR TITLE
Expose templates as filegroup

### DIFF
--- a/cmd/bb_browser/BUILD.bazel
+++ b/cmd/bb_browser/BUILD.bazel
@@ -44,6 +44,12 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "templates",
+    srcs = glob(["templates/**"]),
+    visibility = ["//visibility:public"],
+)
+
 container_layer(
     name = "bb_browser_layer_executable",
     files = [":bb_browser"],
@@ -52,7 +58,7 @@ container_layer(
 container_layer(
     name = "bb_browser_layer_templates",
     data_path = ".",
-    files = glob(["templates/**"]),
+    files = [":templates"],
 )
 
 container_image(


### PR DESCRIPTION
With this, we can use Bazel for the bare deployments in bb-deployments (i.e. in [this PR](https://github.com/buildbarn/bb-deployments/pull/22)).