### PR TITLE
Fix the web site favicon

### DIFF
--- a/cmd/bb_browser/main.go
+++ b/cmd/bb_browser/main.go
@@ -130,7 +130,7 @@ func main() {
 			routePrefix += "/"
 		}
 
-		faviconURL := template.URL("data:image/png;base64," + base64.URLEncoding.EncodeToString(favicon))
+		faviconURL := template.URL("data:image/png;base64," + base64.StdEncoding.EncodeToString(favicon))
 		templates, err := template.New("templates").Funcs(template.FuncMap{
 			"basename":    path.Base,
 			"favicon_url": func() template.URL { return faviconURL },

--- a/cmd/bb_browser/templates/header.html
+++ b/cmd/bb_browser/templates/header.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<title>Buildbarn Browser</title>
-		<link href="{{favicon_url}}" rel="shortcut icon">
+		<link href="{{favicon_url}}" rel="icon">
 		<style>{{stylesheet}}</style>
 	</head>
 	<body>


### PR DESCRIPTION
It has been broken since 2021-09-09, commit c4d0a622a4c4c27a144ebd569193ce69bed61042.

- The wrong base64 encoding was applied.
- Use `icon` instead of deprecated `shurtcut icon`, see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#icon