### PR TITLE
 Fix reference to toolchains_llvm after repo rename

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,9 +97,9 @@ switched_rules_by_language(
 http_archive(
     name = "com_grail_bazel_toolchain",
     canonical_id = "0.7.2",
-    sha256 = "f7aa8e59c9d3cafde6edb372d9bd25fb4ee7293ab20b916d867cd0baaa642529",
-    strip_prefix = "bazel-toolchain-0.7.2",
-    url = "https://github.com/grailbio/bazel-toolchain/archive/0.7.2.tar.gz",
+    sha256 = "ea7d247dd4a0058c008a6e8fa0855a69d57b0cb500271c7b48c1a28512608ecd",
+    strip_prefix = "toolchains_llvm-0.7.2",
+    url = "https://github.com/bazel-contrib/toolchains_llvm/archive/refs/tags/0.7.2.tar.gz",
 )
 
 load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")


### PR DESCRIPTION
The toolchains_llvm project was renamed which resulted in modified paths and consequently shasums of release packages.

The toolchain is used by clang format in the github actions.

See:
https://github.com/bazel-contrib/toolchains_llvm/blob/ba56fd425865e71a9e9dd43b850e587a98634113/REPO_RENAME.md