### PR TITLE
Make maximumLogSizeBytes configurable

### DIFF
--- a/cmd/bb_browser/browser_service.go
+++ b/cmd/bb_browser/browser_service.go
@@ -99,19 +99,21 @@ type BrowserService struct {
 	initialSizeClassCache        blobstore.BlobAccess
 	fileSystemAccessCache        blobstore.BlobAccess
 	maximumMessageSizeBytes      int
+	maximumLogSizeBytes          int
 	templates                    *template.Template
 	bbClientdInstanceNamePatcher digest.InstanceNamePatcher
 }
 
 // NewBrowserService constructs a BrowserService that accesses storage
 // through a set of handles.
-func NewBrowserService(contentAddressableStorage, actionCache, initialSizeClassCache, fileSystemAccessCache blobstore.BlobAccess, maximumMessageSizeBytes int, templates *template.Template, bbClientdInstanceNamePatcher digest.InstanceNamePatcher, router *mux.Router) *BrowserService {
+func NewBrowserService(contentAddressableStorage, actionCache, initialSizeClassCache, fileSystemAccessCache blobstore.BlobAccess, maximumMessageSizeBytes int, maximumLogSizeBytes int, templates *template.Template, bbClientdInstanceNamePatcher digest.InstanceNamePatcher, router *mux.Router) *BrowserService {
 	s := &BrowserService{
 		contentAddressableStorage:    contentAddressableStorage,
 		actionCache:                  actionCache,
 		initialSizeClassCache:        initialSizeClassCache,
 		fileSystemAccessCache:        fileSystemAccessCache,
 		maximumMessageSizeBytes:      maximumMessageSizeBytes,
+		maximumLogSizeBytes:          maximumLogSizeBytes,
 		templates:                    templates,
 		bbClientdInstanceNamePatcher: bbClientdInstanceNamePatcher,
 	}
@@ -300,7 +302,7 @@ func (s *BrowserService) getLogInfoFromActionResult(ctx context.Context, name st
 }
 
 func (s *BrowserService) getLogInfoForDigest(ctx context.Context, name string, digest digest.Digest) (*logInfo, error) {
-	maximumLogSizeBytes := 100000
+	maximumLogSizeBytes := s.maximumLogSizeBytes
 	if size := digest.GetSizeBytes(); size == 0 {
 		// No log file present.
 		return nil, nil

--- a/cmd/bb_browser/main.go
+++ b/cmd/bb_browser/main.go
@@ -304,12 +304,17 @@ func main() {
 
 		router := mux.NewRouter()
 		subrouter := router.PathPrefix(routePrefix).Subrouter()
+		maximumLogSizeBytes := int(configuration.MaximumLogSizeBytes)
+		if maximumLogSizeBytes == 0 {
+			maximumLogSizeBytes = 100000
+		}
 		NewBrowserService(
 			contentAddressableStorage,
 			actionCache,
 			initialSizeClassCache,
 			fileSystemAccessCache,
 			int(configuration.MaximumMessageSizeBytes),
+			maximumLogSizeBytes,
 			templates,
 			bbClientdInstanceNamePatcher,
 			subrouter)

--- a/pkg/proto/configuration/bb_browser/bb_browser.proto
+++ b/pkg/proto/configuration/bb_browser/bb_browser.proto
@@ -90,4 +90,9 @@ message ApplicationConfiguration {
   // expression `{}` (including the backticks).
   buildbarn.configuration.jmespath.Expression
       request_metadata_links_jmespath_expression = 11;
+
+  // Maximum log size to display inline in the web UI. Logs larger than
+  // this will show a link to download instead of displaying inline.
+  // Defaults to 100000 bytes if not specified.
+  int64 maximum_log_size_bytes = 12;
 }


### PR DESCRIPTION
The default 100000 is a bit small for some use cases. Making maximumLogSizeBytes configurable allows users to see more logs inline.