### PR TITLE
Fix broken gRPC client configuration

### DIFF
--- a/config/browser.jsonnet
+++ b/config/browser.jsonnet
@@ -5,12 +5,12 @@
   blobstore: {
     actionCache: {
       grpc: {
-        address: 'bb-storage:8980',
+        client: { address: 'bb-storage:8980' },
       },
     },
     contentAddressableStorage: {
       grpc: {
-        address: 'bb-storage:8980',
+        client: { address: 'bb-storage:8980' },
       },
     },
   },


### PR DESCRIPTION
The configuration of gRPC clients was recently changed, but `config/browser.jsonnet` was not updated accordingly.